### PR TITLE
Invalidate doesn't work, even in the UI thread.

### DIFF
--- a/src/glide3/java/com/bumptech/glide/supportapp/github/_1062_html_gif_spans/GlideImageGetter.java
+++ b/src/glide3/java/com/bumptech/glide/supportapp/github/_1062_html_gif_spans/GlideImageGetter.java
@@ -88,7 +88,12 @@ final class GlideImageGetter implements Html.ImageGetter, Drawable.Callback {
 		}
 	}
 	@Override public void invalidateDrawable(Drawable who) {
-		targetView.invalidate();
+		targetView.post(new Runnable() {
+		    @Override
+		    public void run() {
+			targetView.setText(targetView.getText());
+		    }
+		});
 	}
 	@Override public void scheduleDrawable(Drawable who, Runnable what, long when) {
 


### PR DESCRIPTION
I got this work by changing targetView.invalidate(), but somehow the images overlapped letters in Textview. 
Not sure why it happened.

It seems to be a strange behavior of Html.ImageGetter, will try.

After attempting for a while, setText(getText()) will mess up the layout. Invalidate() does not work.