### PR TITLE
Fix Renovate in the repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,13 +8,13 @@ repositories {
 	// https://github.com/bumptech/glide/wiki/Snapshots#building-snapshots-locally
 	if (project.hasProperty("local.repo")) {
 		maven {
-			name = "glide-local"
+			name = "Glide Local"
 			url = uri(project.property("local.repo")!!)
 		}
 	}
 	// https://github.com/bumptech/glide/wiki/Snapshots#obtaining-snapshots
 	maven {
-		name = "glide-snapshot"
+		name = "Glide Snapshot"
 		url = uri("https://oss.sonatype.org/content/repositories/snapshots")
 	}
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,16 @@ repositories {
 	google()
 	// https://github.com/bumptech/glide/wiki/Snapshots#building-snapshots-locally
 	if (project.hasProperty("local.repo")) {
-		maven("glide-local") { setUrl(project.property("local.repo")!!) }
+		maven {
+			name = "glide-local"
+			url = uri(project.property("local.repo")!!)
+		}
 	}
 	// https://github.com/bumptech/glide/wiki/Snapshots#obtaining-snapshots
-	maven("glide-snapshot") { setUrl("https://oss.sonatype.org/content/repositories/snapshots") }
+	maven {
+		name = "glide-snapshot"
+		url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+	}
 }
 
 android {


### PR DESCRIPTION
It doesn't recognize `glide4 = "4.15.0-SNAPSHOT"` in shadow toml, because it doesn't see the snapshot repository in the build.gradle file.