### PR TITLE
Raise Android compileSdk from 35 to 36

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ java {
 }
 
 android {
-	compileSdk = 35
+	compileSdk = 36
 	namespace = "com.bumptech.glide.supportapp"
 	defaultConfig {
 		@Suppress("MinSdkTooLow") // Latest requirement: https://github.com/ebelinski/apilevels/pull/74


### PR DESCRIPTION
Separate prerequisite for dependency upgrades requiring compileSdk 36.