### PR TITLE
Raise Android compileSdk from 36 to 37

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ java {
 }
 
 android {
-	compileSdk = 36
+	compileSdk = 37
 	namespace = "com.bumptech.glide.supportapp"
 	defaultConfig {
 		@Suppress("MinSdkTooLow") // Latest requirement: https://github.com/ebelinski/apilevels/pull/74


### PR DESCRIPTION
Follow-up to #517. Raises compileSdk for dependencies requiring Android API 37.